### PR TITLE
Rewrite logic to remove excess ifs for margins

### DIFF
--- a/src/components/Categories/index.js
+++ b/src/components/Categories/index.js
@@ -9,13 +9,13 @@ const Categories = ({ categories, selectedCategory, onCategoryPress }) => {
             data={categories}
             keyExtractor={item => String(item)}
             showsHorizontalScrollIndicator={false}
-            renderItem={({ item, index }) => {
+            renderItem={({ item }) => {
                 const selected = selectedCategory === item;
 
                 return (
                     <TouchableOpacity
                         onPress={() => onCategoryPress(item)}
-                        style={[styles.itemContainer, selected ? styles.selectedItemContainer : {}, index === 0 ? { marginLeft: 32 } : {}]}
+                        style={[styles.itemContainer, selected ? styles.selectedItemContainer : {}]}
                     >
                         <Text style={[styles.item, selected ? styles.selectedItem : {}]}>{item}</Text>
                     </TouchableOpacity>

--- a/src/components/Categories/styles.js
+++ b/src/components/Categories/styles.js
@@ -11,6 +11,7 @@ const styles = StyleSheet.create({
     },
     itemContainer: {
         marginRight: 17,
+        marginTop: 5,
         marginBottom: 14,
     },
     selectedItemContainer: {

--- a/src/screens/Home/index.js
+++ b/src/screens/Home/index.js
@@ -30,13 +30,14 @@ const Home = () => {
     return (
         <SafeAreaView style={styles.container}>
             <FlatList
+                showsVerticalScrollIndicator={false}
                 data={data}
                 numColumns={2}
-                style={{ flexGrow: 1 }}
+                style={{ flexGrow: 1, margin: 32 }}
                 ListEmptyComponent={(<Text style={styles.emptyText}>No items found.</Text>)}
                 ListHeaderComponent={(
                     <>
-                        <View style={{ margin: 32 }}>
+                        <View>
                             <Title text='Where do' style={{ fontWeight: 'normal' }} />
                             <Title text='you want to go' />
 
@@ -54,9 +55,7 @@ const Home = () => {
                 renderItem={({ item, index }) => (
                     <AttractionCard
                         key={item.id}
-                        style={index % 2 === 0
-                            ? { marginRight: 12,  marginLeft: 32 }
-                            : { marginRight: 32 }}
+                        style={index % 2 === 0 ? { marginRight: 12 } : {}}
                         title={item.name}
                         subtitle={item.city}
                         imageSrc={item.images?.length ? item.images[0] : null}


### PR DESCRIPTION
Lesson:
33. Using FlatList

Reason for rewrite:
Having excess if logic, may prevent beginners from fully appreciating the art of FlatList.
Nonetheless, Elina did a good job to explain the transition from ScrollView to FlatList.

Rewrite:
Basically, define this line in the main FlatList in Home\index.js
style={{ flexGrow: 1, margin: 32 }}
This will help to remove excess if margin logic in AttractionCard and Categories.